### PR TITLE
Revert "revert add star class"

### DIFF
--- a/app/src/main/java/com/example/cmput301w21t26/Star.java
+++ b/app/src/main/java/com/example/cmput301w21t26/Star.java
@@ -1,0 +1,5 @@
+package com.example.cmput301w21t26;
+
+public class Star extends Shape {
+
+}


### PR DESCRIPTION
Reverts CMPUT301W21T26/CMPUT301W21T26#4

Original pull request was to revert the added star class; accidently merged this change with main.